### PR TITLE
sort by a/c/m time of files to be cleaned

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Attributes
 - `dry_run` - `true`/`false` Defaults to `false`. If `true` will disable actual file operations.`
 - `files` - `true`/`false` Defaults to `true`. If false will ignore files during cleanup.
 - `directories` - `true`/`false` Defaults to `true`. If false will ignore directories during cleanup.
+- `sort_by` - `:atime`/`:ctime`/`:mtime` Defaults to `:mtime`. Sort the files to be deleted by their (a)ccess, (c)reate or (m)odified time.
 
 `keep_last` and `older_than` are mutally exclusive since I can't think of any way combining them makes sense.
 

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -1,9 +1,15 @@
-
 actions :clean
 
 VALID_TIME_KEYS = [:minutes, :hours, :days, :weeks]
+VALID_SORT_KEYS = [:mtime, :atime, :ctime]
 
 attribute :name, kind_of: String
+attribute :sort_by, kind_of: Symbol, default: :mtime, callbacks: {
+  "value must be one of #{VALID_SORT_KEYS.inspect}" => lambda do |v|
+    VALID_SORT_KEYS.include?(v)
+  end
+}
+attribute :except, kind_of: String
 attribute :dry_run, kind_of: [TrueClass, FalseClass], default: false
 attribute :files, kind_of: [TrueClass, FalseClass], default: true
 attribute :directories, kind_of: [TrueClass, FalseClass], default: true
@@ -11,7 +17,7 @@ attribute :keep_last, kind_of: Integer
 attribute :older_than, kind_of: Hash, callbacks: {
   "keys must be one of #{VALID_TIME_KEYS.inspect}" => lambda do |time|
     keys = time.keys.map(&:to_sym)
-    keys.select { |k| VALID_TIME_KEYS.include?(k) }.empty?
+    keys.map { |k| VALID_TIME_KEYS.include?(k) }.all?
   end,
   'value must be an integer' => lambda { |time| time[time.keys.first].is_a? Integer }
 }


### PR DESCRIPTION
Change is [here](https://github.com/racker/cookbook-cleanup/commit/5bbe89fc119f6411899ff25f885d4a441e6b0023), will be clearer after a rebase when #2 is merged.

This is a little-used cookbook, but my team has added some features to it and I'd like to push them upstream. Specifically, the ability to sort the files by `(a)ccess`, `(c)reate`, `(m)odified` time of the file.

I don't believe anything is break for old users. Feedback welcome.