### PR TITLE
Final round improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 metadata.json
 
+.kitchen/
+.kitchen.local.yml
+
+Berksfile.lock
+Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,9 @@
+# Offense count: 2
+# Configuration parameters: AllowURI, URISchemes.
+Metrics/LineLength:
+  Max: 100
+
+# Offense count: 1
+# Configuration parameters: MinBodyLength.
+Style/GuardClause:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+  - 2.0.0
+bundler_args: --without development
+gemfile:
+  - Gemfile
+script: bundle exec rake travis:ci

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+# encoding: UTF-8
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+source 'https://rubygems.org'
+
+group :style do
+  gem 'foodcritic', '~> 3.0'
+  gem 'rubocop', '~> 0.24'
+end

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/racker/cookbook-cleanup.svg)](https://travis-ci.org/racker/cookbook-cleanup)
+[![Chef cookbook](https://img.shields.io/cookbook/v/cleanup.svg)](https://supermarket.chef.io/cookbooks/cleanup)
+
 Description
 ===========
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,28 @@
+# encoding: UTF-8
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+# Based on magic_shell cookbook code, thanks @sethvargo.
+
+# More info at https://github.com/jimweirich/rake/blob/master/doc/rakefile.rdoc
+
+require 'bundler/setup'
+
+namespace :style do
+  require 'rubocop/rake_task'
+  desc 'Run Ruby style checks'
+  RuboCop::RakeTask.new(:ruby)
+
+  require 'foodcritic'
+  desc 'Run Chef style checks'
+  FoodCritic::Rake::LintTask.new(:chef)
+end
+
+desc 'Run all style checks'
+task style: %w(style:chef style:ruby)
+
+namespace :travis do
+  desc 'Run tests on Travis'
+  task ci: %w(style)
+end
+
+task default: %w(style)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ license 'Apache 2.0'
 name 'cleanup'
 description 'Installs/Configures cleanup'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.0.1'
+version '0.1.0'

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -17,6 +17,7 @@ action :clean do
     end
     do_not_delete = do_not_delete.realpath if do_not_delete.symlink?
     files.delete(do_not_delete)
+    new_resource.updated_by_last_action(true)
   end
   Chef::Log.debug "Found dirs: #{files.join(',')}"
   if new_resource.keep_last
@@ -28,6 +29,7 @@ action :clean do
       kill_file(file)
       Chef::Log.info "#{dry_run_str}Removed #{file}"
     end
+    new_resource.updated_by_last_action(true)
   elsif new_resource.older_than
     ot = new_resource.older_than
     time = Time.now.to_i
@@ -39,6 +41,7 @@ action :clean do
     files.each do |file|
       if file.lstat.send(new_resource.sort_by) < Time.at(new_time)
         kill_file(file)
+        new_resource.updated_by_last_action(true)
         Chef::Log.info "#{dry_run_str}Deleting #{file}"
       else
         Chef::Log.info "#{dry_run_str}Not deleting #{file}"

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -19,7 +19,7 @@ attribute :older_than, kind_of: Hash, callbacks: {
     keys = time.keys.map(&:to_sym)
     keys.map { |k| VALID_TIME_KEYS.include?(k) }.all?
   end,
-  'value must be an integer' => lambda { |time| time[time.keys.first].is_a? Integer }
+  'value must be an integer' => ->(time) { time[time.keys.first].is_a? Integer }
 }
 
 def initialize(*args)


### PR DESCRIPTION
This brings us fully in sync with the other fork of the `cleanup` cookbook in use.

- [x] badges, because we're cool kids.
- [x] `.travis.yml` and `Rakefile` for CI linting.
- [x] `.rubocop.yml` to make us pass the lint.
- [x] \(largish) version bump, to ease upgrade path for users of the other cookbook.
- [ ] `.kitchen.yml` to test converge a recipe change.
