### PR TITLE
Only delete it when the file is a regular file

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -60,7 +60,7 @@ def kill_file(file)
   unless new_resource.dry_run
     if new_resource.directories && file.directory?
       file.rmtree
-    elsif new_resource.files
+    elsif new_resource.files && file.file?
       file.delete
     end
   end


### PR DESCRIPTION
Without the fix, the recipe will fail when it tries to delete a directory even though the new_resource.directories is set to `fasle`:

```
Errno::ENOTEMPTY
----------------
Directory not empty @ dir_s_rmdir - </path/to/directory/>
```